### PR TITLE
Can now specify a safe encoding which prevents segfaults in containers. Fixes #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.vscode

--- a/goheif.go
+++ b/goheif.go
@@ -12,6 +12,10 @@ import (
 	"github.com/jdeng/goheif/libde265"
 )
 
+// SafeEncoding uses more memory but seems to make
+// the library safer to use in containers.
+var SafeEncoding bool
+
 type gridBox struct {
 	columns, rows int
 	width, height int
@@ -100,7 +104,10 @@ func Decode(r io.Reader) (image.Image, error) {
 		return nil, fmt.Errorf("No item info")
 	}
 
-	dec := libde265.NewDecoder()
+	dec, err := libde265.NewDecoder(libde265.WithSafeEncoding(SafeEncoding))
+	if err != nil {
+		return nil, err
+	}
 	defer dec.Free()
 	if it.Info.ItemType == "hvc1" {
 		return decodeHevcItem(dec, hf, it)


### PR DESCRIPTION
The feature is opt-in. The default behaviour is the current behaviour.

Here are the benchmarks:

```
BenchmarkSafeEncoding-4      	      20	  90524720 ns/op	 2990679 B/op	     325 allocs/op
BenchmarkRegularEncoding-4   	      20	  86883378 ns/op	  427743 B/op	     318 allocs/op
```

Fixes #1 