### PR TITLE
goheif.DecodeImage changed to goheif.Decode

### DIFF
--- a/heic2jpg/main.go
+++ b/heic2jpg/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/jdeng/goheif"
 	"image/jpeg"
 	"io"
 	"log"
 	"os"
+
+	"github.com/jdeng/goheif"
 )
 
 // Skip Writer for exif writing
@@ -77,7 +78,7 @@ func main() {
 		log.Printf("Warning: no EXIF from %s: %v\n", fin, err)
 	}
 
-	img, err := goheif.DecodeImage(fi)
+	img, err := goheif.Decode(fi)
 	if err != nil {
 		log.Fatalf("Failed to parse %s: %v\n", fin, err)
 	}


### PR DESCRIPTION
Function DecodeImage was renamed to Decode, but not renamed in the sample program. This addresses the following issues:
- https://github.com/jdeng/goheif/issues/5
- https://github.com/jdeng/goheif/issues/6
