### PR TITLE
Silence warnings

### DIFF
--- a/libde265/libde265.go
+++ b/libde265/libde265.go
@@ -1,6 +1,6 @@
 package libde265
 
-//#cgo CXXFLAGS: -Ilibde265 -I. -std=c++11 -Wno-constant-conversion -msse4.1
+//#cgo CXXFLAGS: -Ilibde265 -I. -std=c++11 -msse4.1
 //#cgo CFLAGS: -I.
 // #include <stdint.h>
 // #include <stdlib.h>

--- a/libde265/libde265/cabac.cc
+++ b/libde265/libde265/cabac.cc
@@ -416,8 +416,6 @@ int  decode_CABAC_TR_bypass(CABAC_decoder* decoder, int cRiceParam, int cTRMax)
 }
 
 
-#define MAX_PREFIX 32
-
 int  decode_CABAC_EGk_bypass(CABAC_decoder* decoder, int k)
 {
   int base=0;

--- a/libde265/libde265/cabac.cc
+++ b/libde265/libde265/cabac.cc
@@ -431,7 +431,7 @@ int  decode_CABAC_EGk_bypass(CABAC_decoder* decoder, int k)
         n++;
       }
 
-      if (n == k+MAX_PREFIX) {
+      if (n == k+32) {
         return 0; // TODO: error
       }
     }

--- a/libde265/libde265/slice.cc
+++ b/libde265/libde265/slice.cc
@@ -2444,8 +2444,6 @@ static int decode_coeff_abs_level_greater2(thread_context* tctx,
 }
 
 
-#define MAX_PREFIX 64
-
 static int decode_coeff_abs_level_remaining(thread_context* tctx,
                                             int cRiceParam)
 {
@@ -2457,7 +2455,7 @@ static int decode_coeff_abs_level_remaining(thread_context* tctx,
     prefix++;
     codeword = decode_CABAC_bypass(&tctx->cabac_decoder);
 
-    if (prefix>MAX_PREFIX) {
+    if (prefix>64) {
       return 0; // TODO: error
     }
   }


### PR DESCRIPTION
@huydq189's  fork silences warnings. I have not improved on it, but only removed the go-module name change. Feel free to ignore this PR and cherrypick those two commits.