### PR TITLE
Fix metadata error preservation

### DIFF
--- a/heif/heif.go
+++ b/heif/heif.go
@@ -212,7 +212,8 @@ func (f *File) GetItemData(it *Item) ([]byte, error) {
 }
 
 func (f *File) setMetaErr(err error) error {
-	if f.metaErr != nil {
+	// preserve the first error encountered while parsing metadata
+	if f.metaErr == nil {
 		f.metaErr = err
 	}
 	return err


### PR DESCRIPTION
## Summary
- preserve the first metadata parsing error in heif

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f71e543248331b076689acb95516d