### PR TITLE
use snprintf instead of deprecated sprintf.

### DIFF
--- a/libde265/libde265.cc
+++ b/libde265/libde265.cc
@@ -1,5 +1,2 @@
 #include <stdint.h>
 #include "libde265-all.inl"
-
-
-

--- a/libde265/libde265/deblock.cc
+++ b/libde265/libde265/deblock.cc
@@ -920,7 +920,7 @@ public:
   virtual void work();
   virtual std::string name() const {
     char buf[100];
-    sprintf(buf,"deblock-%d",ctb_y);
+    snprintf(buf,sizeof(buf),"deblock-%d",ctb_y);
     return buf;
   }
 };
@@ -1051,7 +1051,7 @@ void apply_deblocking_filter(de265_image* img) // decoder_context* ctx)
       }
 #if 0
       char buf[1000];
-      sprintf(buf,"lf-after-V-%05d.yuv", ctx->img->PicOrderCntVal);
+      snprintf(buf,sizeof(buf),"lf-after-V-%05d.yuv", ctx->img->PicOrderCntVal);
       write_picture_to_file(ctx->img, buf);
 #endif
 
@@ -1066,7 +1066,7 @@ void apply_deblocking_filter(de265_image* img) // decoder_context* ctx)
       }
 
 #if 0
-      sprintf(buf,"lf-after-H-%05d.yuv", ctx->img->PicOrderCntVal);
+      snprintf(buf,sizeof(buf),"lf-after-H-%05d.yuv", ctx->img->PicOrderCntVal);
       write_picture_to_file(ctx->img, buf);
 #endif
     }

--- a/libde265/libde265/decctx.cc
+++ b/libde265/libde265/decctx.cc
@@ -1898,7 +1898,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
 {
 #if SAVE_INTERMEDIATE_IMAGES
     char buf[1000];
-    sprintf(buf,"pre-lf-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"pre-lf-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 
@@ -1907,7 +1907,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
     }
 
 #if SAVE_INTERMEDIATE_IMAGES
-    sprintf(buf,"pre-sao-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"pre-sao-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 
@@ -1916,7 +1916,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
     }
 
 #if SAVE_INTERMEDIATE_IMAGES
-    sprintf(buf,"sao-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"sao-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 }

--- a/libde265/libde265/sao.cc
+++ b/libde265/libde265/sao.cc
@@ -410,7 +410,7 @@ public:
   virtual void work();
   virtual std::string name() const {
     char buf[100];
-    sprintf(buf,"sao-%d",ctb_y);
+    snprintf(buf,sizeof(buf),"sao-%d",ctb_y);
     return buf;
   }
 };

--- a/libde265/libde265/slice.cc
+++ b/libde265/libde265/slice.cc
@@ -4909,14 +4909,14 @@ bool initialize_CABAC_at_slice_segment_start(thread_context* tctx)
 
 std::string thread_task_ctb_row::name() const {
   char buf[100];
-  sprintf(buf,"ctb-row-%d",debug_startCtbRow);
+  snprintf(buf, sizeof(buf), "ctb-row-%d",debug_startCtbRow);
   return buf;
 }
 
 
 std::string thread_task_slice_segment::name() const {
   char buf[100];
-  sprintf(buf,"slice-segment-%d;%d",debug_startCtbX,debug_startCtbY);
+  snprintf(buf, sizeof(buf), "slice-segment-%d;%d",debug_startCtbX,debug_startCtbY);
   return buf;
 }
 


### PR DESCRIPTION
for some weird reason, this only works when deleting those empty lines in libde265.cc.