### PR TITLE
Fix grid tile stitching with padded strides

### DIFF
--- a/goheif.go
+++ b/goheif.go
@@ -22,6 +22,86 @@ type gridBox struct {
 	width, height int
 }
 
+func chromaDimensions(width, height int, subsample image.YCbCrSubsampleRatio) (int, int) {
+	switch subsample {
+	case image.YCbCrSubsampleRatio422:
+		return (width + 1) / 2, height
+	case image.YCbCrSubsampleRatio420:
+		return (width + 1) / 2, (height + 1) / 2
+	case image.YCbCrSubsampleRatio440:
+		return width, (height + 1) / 2
+	case image.YCbCrSubsampleRatio411:
+		return (width + 3) / 4, height
+	case image.YCbCrSubsampleRatio410:
+		return (width + 3) / 4, (height + 1) / 2
+	default:
+		return width, height
+	}
+}
+
+func chromaYStep(subsample image.YCbCrSubsampleRatio) int {
+	switch subsample {
+	case image.YCbCrSubsampleRatio420, image.YCbCrSubsampleRatio440, image.YCbCrSubsampleRatio410:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func copyPlane(dst []byte, dstStart int, src []byte, srcStart int, width int, plane string) error {
+	if dstStart < 0 || srcStart < 0 {
+		return fmt.Errorf("%s plane offset out of bounds", plane)
+	}
+	if dstStart+width > len(dst) {
+		return fmt.Errorf("%s destination row out of bounds", plane)
+	}
+	if srcStart+width > len(src) {
+		return fmt.Errorf("%s source row out of bounds", plane)
+	}
+
+	copy(dst[dstStart:dstStart+width], src[srcStart:srcStart+width])
+	return nil
+}
+
+func stitchYCbCrTile(dst *image.YCbCr, src *image.YCbCr, tileX, tileY int) error {
+	if dst.SubsampleRatio != src.SubsampleRatio {
+		return errors.New("inconsistent tile subsampling")
+	}
+
+	bounds := src.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+	dstX := tileX * width
+	dstY := tileY * height
+
+	for row := 0; row < height; row++ {
+		srcStart := src.YOffset(bounds.Min.X, bounds.Min.Y+row)
+		dstStart := dst.YOffset(dstX, dstY+row)
+		if err := copyPlane(dst.Y, dstStart, src.Y, srcStart, width, "luma"); err != nil {
+			return err
+		}
+	}
+
+	chromaWidth, chromaHeight := chromaDimensions(width, height, src.SubsampleRatio)
+	dstChromaX := tileX * chromaWidth
+	dstChromaY := tileY * chromaHeight
+	srcChromaYStep := chromaYStep(src.SubsampleRatio)
+
+	for row := 0; row < chromaHeight; row++ {
+		srcStart := src.COffset(bounds.Min.X, bounds.Min.Y+row*srcChromaYStep)
+		dstStart := (dstChromaY+row)*dst.CStride + dstChromaX
+
+		if err := copyPlane(dst.Cb, dstStart, src.Cb, srcStart, chromaWidth, "cb"); err != nil {
+			return err
+		}
+		if err := copyPlane(dst.Cr, dstStart, src.Cr, srcStart, chromaWidth, "cr"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func newGridBox(data []byte) (*gridBox, error) {
 	if len(data) < 8 {
 		return nil, fmt.Errorf("invalid data")
@@ -224,18 +304,8 @@ func Decode(r io.Reader) (image.Image, error) {
 				return nil, errors.New("inconsistent tile dimensions")
 			}
 
-			// copy y stride data
-			for j := 0; j < rect.Dy(); j += 1 {
-				copy(out.Y[(y*tileHeight+j)*out.YStride+x*ycc.YStride:], ycc.Y[j*ycc.YStride:(j+1)*ycc.YStride])
-			}
-
-			// height of c strides
-			cHeight := len(ycc.Cb) / ycc.CStride
-
-			// copy c stride data
-			for j := 0; j < cHeight; j += 1 {
-				copy(out.Cb[(y*cHeight+j)*out.CStride+x*ycc.CStride:], ycc.Cb[j*ycc.CStride:(j+1)*ycc.CStride])
-				copy(out.Cr[(y*cHeight+j)*out.CStride+x*ycc.CStride:], ycc.Cr[j*ycc.CStride:(j+1)*ycc.CStride])
+			if err := stitchYCbCrTile(out, ycc, x, y); err != nil {
+				return nil, err
 			}
 
 			i++

--- a/goheif_grid_test.go
+++ b/goheif_grid_test.go
@@ -1,0 +1,52 @@
+package goheif
+
+import (
+	"image"
+	"reflect"
+	"testing"
+)
+
+func TestStitchYCbCrTileUsesVisibleTileWidth(t *testing.T) {
+	dst := image.NewYCbCr(image.Rect(0, 0, 8, 2), image.YCbCrSubsampleRatio420)
+	src := &image.YCbCr{
+		Y:              []uint8{1, 2, 3, 4, 200, 201, 5, 6, 7, 8, 202, 203},
+		Cb:             []uint8{9, 10, 204, 205},
+		Cr:             []uint8{11, 12, 206, 207},
+		YStride:        6,
+		CStride:        4,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect:           image.Rect(0, 0, 4, 2),
+	}
+
+	if err := stitchYCbCrTile(dst, src, 1, 0); err != nil {
+		t.Fatalf("stitchYCbCrTile returned error: %v", err)
+	}
+
+	wantY := []uint8{
+		0, 0, 0, 0, 1, 2, 3, 4,
+		0, 0, 0, 0, 5, 6, 7, 8,
+	}
+	if !reflect.DeepEqual(dst.Y, wantY) {
+		t.Fatalf("unexpected Y plane: got %v want %v", dst.Y, wantY)
+	}
+
+	wantCb := []uint8{0, 0, 9, 10}
+	if !reflect.DeepEqual(dst.Cb, wantCb) {
+		t.Fatalf("unexpected Cb plane: got %v want %v", dst.Cb, wantCb)
+	}
+
+	wantCr := []uint8{0, 0, 11, 12}
+	if !reflect.DeepEqual(dst.Cr, wantCr) {
+		t.Fatalf("unexpected Cr plane: got %v want %v", dst.Cr, wantCr)
+	}
+}
+
+func TestStitchYCbCrTileRejectsSubsampleMismatch(t *testing.T) {
+	dst := image.NewYCbCr(image.Rect(0, 0, 4, 2), image.YCbCrSubsampleRatio420)
+	src := image.NewYCbCr(image.Rect(0, 0, 4, 2), image.YCbCrSubsampleRatio444)
+
+	err := stitchYCbCrTile(dst, src, 0, 0)
+	if err == nil {
+		t.Fatal("expected stitchYCbCrTile to reject mismatched subsampling")
+	}
+}

--- a/libde265/libde265.go
+++ b/libde265/libde265.go
@@ -11,6 +11,7 @@ package libde265
 import "C"
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"image"
@@ -21,6 +22,17 @@ type Decoder struct {
 	ctx        unsafe.Pointer
 	hasImage   bool
 	safeEncode bool
+}
+
+var nativeEndian binary.ByteOrder
+
+func init() {
+	var probe uint16 = 0x0102
+	if *(*byte)(unsafe.Pointer(&probe)) == 0x02 {
+		nativeEndian = binary.LittleEndian
+	} else {
+		nativeEndian = binary.BigEndian
+	}
 }
 
 func Init() {
@@ -123,6 +135,8 @@ func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 
 			width := C.de265_get_image_width(img, 0)
 			height := C.de265_get_image_height(img, 0)
+			yBits := int(C.de265_get_bits_per_pixel(img, 0))
+			cBits := int(C.de265_get_bits_per_pixel(img, 1))
 
 			var ystride, cstride C.int
 			y := C.de265_get_image_plane(img, 0, &ystride)
@@ -146,24 +160,31 @@ func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 				r = image.YCbCrSubsampleRatio444
 			}
 			ycc := &image.YCbCr{
-				YStride:        int(ystride),
-				CStride:        int(cstride),
 				SubsampleRatio: r,
 				Rect:           image.Rectangle{Min: image.Point{0, 0}, Max: image.Point{int(width), int(height)}},
 			}
-			if dec.safeEncode {
-				ycc.Y = C.GoBytes(unsafe.Pointer(y), C.int(height*ystride))
-				ycc.Cb = C.GoBytes(unsafe.Pointer(cb), C.int(cheight*cstride))
-				ycc.Cr = C.GoBytes(unsafe.Pointer(cr), C.int(cheight*cstride))
-			} else {
-				// Calculate the exact sizes needed
-				ySize := int(height) * int(ystride)
-				cSize := int(cheight) * int(cstride)
 
-				// Create slices directly from pointers with exact sizes
-				ycc.Y = unsafe.Slice((*byte)(y), ySize)
-				ycc.Cb = unsafe.Slice((*byte)(cb), cSize)
-				ycc.Cr = unsafe.Slice((*byte)(cr), cSize)
+			yPlane, yPlaneStride, err := decodePlane(y, int(height), int(ystride), yBits, dec.safeEncode)
+			if err != nil {
+				return nil, err
+			}
+			cbPlane, cPlaneStride, err := decodePlane(cb, int(cheight), int(cstride), cBits, dec.safeEncode)
+			if err != nil {
+				return nil, err
+			}
+			crPlane, crPlaneStride, err := decodePlane(cr, int(cheight), int(cstride), cBits, dec.safeEncode)
+			if err != nil {
+				return nil, err
+			}
+
+			ycc.YStride = yPlaneStride
+			ycc.CStride = cPlaneStride
+			ycc.Y = yPlane
+			ycc.Cb = cbPlane
+			ycc.Cr = crPlane
+
+			if cPlaneStride != crPlaneStride {
+				return nil, fmt.Errorf("chroma stride mismatch: cb=%d cr=%d", cPlaneStride, crPlaneStride)
 			}
 
 			//C.de265_release_next_picture(dec.ctx)
@@ -173,4 +194,60 @@ func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 	}
 
 	return nil, errors.New("no picture")
+}
+
+func decodePlane(ptr *C.uint8_t, height int, strideBytes int, bitsPerPixel int, safeEncode bool) ([]byte, int, error) {
+	if ptr == nil {
+		return nil, 0, errors.New("nil image plane")
+	}
+	if height < 0 || strideBytes <= 0 {
+		return nil, 0, fmt.Errorf("invalid plane dimensions: height=%d stride=%d", height, strideBytes)
+	}
+
+	size := height * strideBytes
+	var src []byte
+	if safeEncode {
+		src = C.GoBytes(unsafe.Pointer(ptr), C.int(size))
+	} else {
+		src = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+	}
+
+	if bitsPerPixel <= 8 {
+		return src, strideBytes, nil
+	}
+
+	return unpackHighBitDepthPlane(src, height, strideBytes, bitsPerPixel)
+}
+
+func unpackHighBitDepthPlane(src []byte, height int, strideBytes int, bitsPerPixel int) ([]byte, int, error) {
+	bytesPerSample := (bitsPerPixel + 7) / 8
+	if bytesPerSample <= 1 {
+		return nil, 0, fmt.Errorf("invalid bytes per sample for %d-bit plane", bitsPerPixel)
+	}
+	if strideBytes%bytesPerSample != 0 {
+		return nil, 0, fmt.Errorf("stride %d is not aligned to %d-byte samples", strideBytes, bytesPerSample)
+	}
+
+	strideSamples := strideBytes / bytesPerSample
+	out := make([]byte, height*strideSamples)
+	shift := bitsPerPixel - 8
+
+	for row := 0; row < height; row++ {
+		srcRow := src[row*strideBytes : (row+1)*strideBytes]
+		dstRow := out[row*strideSamples : (row+1)*strideSamples]
+		for col := 0; col < strideSamples; col++ {
+			offset := col * bytesPerSample
+			var sample uint16
+			switch bytesPerSample {
+			case 2:
+				sample = nativeEndian.Uint16(srcRow[offset : offset+2])
+			default:
+				return nil, 0, fmt.Errorf("unsupported %d-byte samples", bytesPerSample)
+			}
+
+			dstRow[col] = byte(sample >> shift)
+		}
+	}
+
+	return out, strideSamples, nil
 }

--- a/libde265/libde265_test.go
+++ b/libde265/libde265_test.go
@@ -1,0 +1,49 @@
+package libde265
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+func appendUint16(dst []byte, value uint16) []byte {
+	buf := make([]byte, 2)
+	nativeEndian.PutUint16(buf, value)
+	return append(dst, buf...)
+}
+
+func TestUnpackHighBitDepthPlane10Bit(t *testing.T) {
+	row1 := []uint16{0, 4, 512, 1023}
+	row2 := []uint16{16, 64, 768, 900}
+	src := make([]byte, 0, 2*(len(row1)+len(row2)))
+	for _, sample := range append(row1, row2...) {
+		src = appendUint16(src, sample)
+	}
+
+	got, stride, err := unpackHighBitDepthPlane(src, 2, 8, 10)
+	if err != nil {
+		t.Fatalf("unpackHighBitDepthPlane returned error: %v", err)
+	}
+
+	if stride != 4 {
+		t.Fatalf("unexpected stride: got %d want 4", stride)
+	}
+
+	want := []byte{
+		0, 1, 128, 255,
+		4, 16, 192, 225,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected plane bytes: got %v want %v", got, want)
+	}
+}
+
+func TestUnpackHighBitDepthPlaneRejectsMisalignedStride(t *testing.T) {
+	src := make([]byte, 9)
+	binary.LittleEndian.PutUint16(src[:2], 1023)
+
+	_, _, err := unpackHighBitDepthPlane(src, 1, 9, 10)
+	if err == nil {
+		t.Fatal("expected unpackHighBitDepthPlane to reject a misaligned stride")
+	}
+}


### PR DESCRIPTION
## Summary
- place grid tiles using their visible width and height instead of decoder stride padding
- normalize high bit-depth HEVC planes to 8-bit samples before exposing them as `image.YCbCr`
- add regression coverage for padded Y/C stride tiles, subsample mismatch, and 10-bit plane unpacking

## Why
Some valid tiled HEIF images decode to YCbCr tiles whose `YStride` and `CStride` are larger than the visible tile width. The previous grid assembly code used those stride values as x offsets, which can overrun the destination plane buffers and panic with slice-bounds errors.

There is a second issue for Main 10 / 10-bit HEVC tiles: `libde265` returns plane strides in bytes, and the previous wrapper passed those raw 16-bit planes through as if they were 8-bit `image.YCbCr` data. That removes the panic but still produces green-tinted output with vertical striping. The wrapper now detects high bit-depth planes, unpacks them to 8-bit sample planes, and sets `YStride`/`CStride` in sample units.

Concrete repro: `10bits_version.heic` (grid 8x4, 512x512 tiles, HEVC Main 10) panicked on `master`, then rendered incorrectly after the initial stitch fix, and now decodes correctly.

## Testing
- `go test ./...`
- converted `10bits_version.heic` with patched `cmd/heic2jpg`
- visually compared patched output against `heif-convert` output
