### PR TITLE
Add init. FreeBSD support

### DIFF
--- a/dav1d/config.h
+++ b/dav1d/config.h
@@ -22,8 +22,8 @@
 #define CONFIG_MACOS_KPERF 0
 
 /* Platform and architecture validation */
-#if !(defined(__linux__) || defined(__APPLE__) || defined(_WIN32))
-#error "Unsupported platform. Only Linux, macOS, and Windows are supported."
+#if !(defined(__linux__) || defined(__APPLE__) || defined(_WIN32) || defined(__FreeBSD__))
+#error "Unsupported platform. Only Linux, macOS, FreeBSD, and Windows are supported."
 #endif
 
 #if !(defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__riscv))
@@ -59,7 +59,11 @@
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_UNISTD_H 1
 #define HAVE_IO_H 0
+#if defined(__FreeBSD__)
+#define HAVE_PTHREAD_NP_H 1
+#else
 #define HAVE_PTHREAD_NP_H 0
+#endif
 
 /* dlsym support */
 #if defined(__linux__)

--- a/dav1d/dav1d.go
+++ b/dav1d/dav1d.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"image"
 	"runtime"
+	"syscall"
 	"unsafe"
 )
 
@@ -76,6 +77,10 @@ func (dec *Decoder) Reset() {
 	}
 }
 
+func isEagain(ret C.int) bool {
+	return ret == -C.int(syscall.EAGAIN)
+}
+
 func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 	if dec.hasPicture {
 		fmt.Printf("previous image may leak")
@@ -102,14 +107,14 @@ func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 		if ret == 0 {
 			break // Data consumed successfully
 		}
-		if ret == -11 { // DAV1D_ERR(EAGAIN) - decoder buffer full, need to get pictures first
+		if isEagain(ret) { // DAV1D_ERR(EAGAIN) - decoder buffer full, need to get pictures first
 			// Try to get a picture to free up decoder buffer
 			var tempPicture C.Dav1dPicture
 			picRet := C.dav1d_get_picture(dec.ctx, &tempPicture)
 			if picRet == 0 {
 				C.dav1d_picture_unref(&tempPicture) // We don't need this intermediate picture
 				continue                            // Try sending data again
-			} else if picRet != -11 { // Not EAGAIN, real error
+			} else if !isEagain(picRet) { // Not EAGAIN, real error
 				return nil, fmt.Errorf("intermediate get_picture error: %d", picRet)
 			}
 			// If picRet == EAGAIN, continue the loop to try send_data again
@@ -126,7 +131,7 @@ func (dec *Decoder) DecodeImage(data []byte) (image.Image, error) {
 		if ret == 0 {
 			break // Successfully got picture
 		}
-		if ret == -11 { // DAV1D_ERR(EAGAIN) - not enough data yet, but this is normal
+		if isEagain(ret) { // DAV1D_ERR(EAGAIN) - not enough data yet, but this is normal
 			if i == maxRetries-1 {
 				return nil, fmt.Errorf("decoder unable to produce picture after %d attempts (may need more data)", maxRetries)
 			}


### PR DESCRIPTION
EAGAIN on FreeBSD is -35

Hacking platform support:

```
(cmd)$ go test -v .
# github.com/jdeng/goheif/dav1d
In file included from dav1d.c:1:
In file included from ./dav1d-base.inl:4:
./src/cpu.c:101:10: warning: call to undeclared function 'pthread_getaffinity_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
=== RUN   TestStitchYCbCrTileUsesVisibleTileWidth
--- PASS: TestStitchYCbCrTileUsesVisibleTileWidth (0.00s)
=== RUN   TestStitchYCbCrTileRejectsSubsampleMismatch
--- PASS: TestStitchYCbCrTileRejectsSubsampleMismatch (0.00s)
=== RUN   TestFormatRegistered
    goheif_test.go:30: Successfully decoded HEIC image: 1596x1064
--- PASS: TestFormatRegistered (0.09s)
=== RUN   TestDecodeAVIF
    goheif_test.go:43: Failed to decode AVIF image: get_picture error: -35
--- FAIL: TestDecodeAVIF (0.01s)
FAIL
FAIL	github.com/jdeng/goheif	0.102s
FAIL
```

Checking for -11 or -35:

```
(cmd)$ go test -v .
=== RUN   TestStitchYCbCrTileUsesVisibleTileWidth
--- PASS: TestStitchYCbCrTileUsesVisibleTileWidth (0.00s)
=== RUN   TestStitchYCbCrTileRejectsSubsampleMismatch
--- PASS: TestStitchYCbCrTileRejectsSubsampleMismatch (0.00s)
=== RUN   TestFormatRegistered
    goheif_test.go:30: Successfully decoded HEIC image: 1596x1064
--- PASS: TestFormatRegistered (0.09s)
=== RUN   TestDecodeAVIF
    goheif_test.go:56: Successfully decoded AVIF image: 1204x800
--- PASS: TestDecodeAVIF (0.03s)
PASS
ok  	github.com/jdeng/goheif	(cached)
```
