### PR TITLE
Expose HEVC Annex-B decoder

### DIFF
--- a/goheif_test.go
+++ b/goheif_test.go
@@ -2,10 +2,13 @@ package goheif
 
 import (
 	"bytes"
+	"encoding/binary"
 	"image"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/jdeng/goheif/heif"
 )
 
 func TestFormatRegistered(t *testing.T) {
@@ -56,6 +59,17 @@ func TestDecodeAVIF(t *testing.T) {
 	t.Logf("Successfully decoded AVIF image: %dx%d", bounds.Dx(), bounds.Dy())
 }
 
+func TestDecodeHEVCAnnexB(t *testing.T) {
+	stream, width, height := testHEVCAnnexBStream(t, "testdata/camel.heic")
+	img, err := DecodeHEVCAnnexB(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := img.Bounds(); got.Dx() != width || got.Dy() != height {
+		t.Fatalf("decoded image size = %dx%d, want %dx%d", got.Dx(), got.Dy(), width, height)
+	}
+}
+
 func BenchmarkSafeEncoding(b *testing.B) {
 	benchEncoding(b, true)
 }
@@ -85,4 +99,68 @@ func benchEncoding(b *testing.B, safe bool) {
 		Decode(r)
 		r.Seek(0, io.SeekStart)
 	}
+}
+
+func testHEVCAnnexBStream(t *testing.T, path string) ([]byte, int, int) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf := heif.Open(bytes.NewReader(data))
+	item, err := hf.PrimaryItem()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Info != nil && item.Info.ItemType == "grid" {
+		dimg := item.Reference("dimg")
+		if dimg == nil || len(dimg.ToItemIDs) == 0 {
+			t.Fatal("grid item has no dimg references")
+		}
+		item, err = hf.ItemByID(dimg.ToItemIDs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if item.Info == nil || item.Info.ItemType != "hvc1" {
+		t.Fatalf("test item type = %v, want hvc1", item.Info)
+	}
+	width, height, ok := item.SpatialExtents()
+	if !ok {
+		t.Fatal("test item has no spatial extents")
+	}
+	config, ok := item.HevcConfig()
+	if !ok {
+		t.Fatal("test item has no hvcC")
+	}
+	itemData, err := hf.GetItemData(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sample bytes.Buffer
+	sample.Write(config.AsHeader())
+	sample.Write(itemData)
+	return lengthPrefixedNALSampleToAnnexB(t, sample.Bytes()), width, height
+}
+
+func lengthPrefixedNALSampleToAnnexB(t *testing.T, sample []byte) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	for len(sample) > 0 {
+		if len(sample) < 4 {
+			t.Fatalf("truncated nal length: %d bytes left", len(sample))
+		}
+		size := int(binary.BigEndian.Uint32(sample[:4]))
+		sample = sample[4:]
+		if size <= 0 || size > len(sample) {
+			t.Fatalf("invalid nal size %d with %d bytes left", size, len(sample))
+		}
+		out.Write([]byte{0, 0, 0, 1})
+		out.Write(sample[:size])
+		sample = sample[size:]
+	}
+	return out.Bytes()
 }

--- a/hevc.go
+++ b/hevc.go
@@ -1,0 +1,84 @@
+package goheif
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image"
+
+	"github.com/jdeng/goheif/libde265"
+)
+
+// DecodeHEVCAnnexB decodes one HEVC still picture from an Annex-B byte stream.
+func DecodeHEVCAnnexB(data []byte) (image.Image, error) {
+	sample, err := annexBToNALSample(data)
+	if err != nil {
+		return nil, err
+	}
+	dec, err := libde265.NewDecoder(libde265.WithSafeEncoding(SafeEncoding))
+	if err != nil {
+		return nil, err
+	}
+	defer dec.Free()
+	return dec.DecodeImage(sample)
+}
+
+func annexBToNALSample(data []byte) ([]byte, error) {
+	starts := annexBStartCodes(data)
+	if len(starts) == 0 {
+		return nil, errors.New("no annex-b start codes")
+	}
+
+	out := bytes.NewBuffer(make([]byte, 0, len(data)))
+	for index, start := range starts {
+		nalStart := start + annexBStartCodeLen(data[start:])
+		nalEnd := len(data)
+		if index+1 < len(starts) {
+			nalEnd = starts[index+1]
+		}
+		for nalEnd > nalStart && data[nalEnd-1] == 0 {
+			nalEnd--
+		}
+		if nalEnd <= nalStart {
+			continue
+		}
+		size := nalEnd - nalStart
+		if size > int(^uint32(0)) {
+			return nil, fmt.Errorf("nal too large: %d bytes", size)
+		}
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(size))
+		out.Write(length[:])
+		out.Write(data[nalStart:nalEnd])
+	}
+	if out.Len() == 0 {
+		return nil, errors.New("empty nal sample")
+	}
+	return out.Bytes(), nil
+}
+
+func annexBStartCodes(data []byte) []int {
+	starts := make([]int, 0, 16)
+	for i := 0; i < len(data)-2; i++ {
+		if data[i] != 0 || data[i+1] != 0 {
+			continue
+		}
+		switch {
+		case data[i+2] == 1:
+			starts = append(starts, i)
+			i += 2
+		case i+3 < len(data) && data[i+2] == 0 && data[i+3] == 1:
+			starts = append(starts, i)
+			i += 3
+		}
+	}
+	return starts
+}
+
+func annexBStartCodeLen(data []byte) int {
+	if len(data) >= 4 && data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 1 {
+		return 4
+	}
+	return 3
+}


### PR DESCRIPTION
## Summary
- add DecodeHEVCAnnexB for decoding raw HEVC Annex-B still-picture streams through libde265
- convert Annex-B start-code delimited NAL units to the length-prefixed sample format expected by the existing decoder
- cover the API by deriving an Annex-B stream from the existing camel.heic HEVC test fixture

## Tests
- GOCACHE=/tmp/.gocache go test ./...