### PR TITLE
libde265: backport upstream OOB-write fixes (CVE-2026-33165, CVE-2026-49295)

### DIFF
--- a/libde265/libde265/image.cc
+++ b/libde265/libde265/image.cc
@@ -453,8 +453,13 @@ de265_error de265_image::alloc_image(int w,int h, enum de265_chroma c,
 
     // CTB info
 
+    // Also reallocate when the CTB size changes even if the unit dimensions stay
+    // constant: a stale ctb_info.log2unitSize otherwise makes set_SliceHeaderIndex
+    // index past the metadata array (heap OOB write).  Backport of upstream
+    // libde265 c7891e41 (1.0.17).
     if (ctb_info.width_in_units != sps->PicWidthInCtbsY ||
-        ctb_info.height_in_units != sps->PicHeightInCtbsY)
+        ctb_info.height_in_units != sps->PicHeightInCtbsY ||
+        ctb_info.log2unitSize    != sps->Log2CtbSizeY)
       {
         delete[] ctb_progress;
 

--- a/libde265/libde265/refpic.cc
+++ b/libde265/libde265/refpic.cc
@@ -318,6 +318,22 @@ bool read_short_term_ref_pic_set(error_queue* errqueue,
 
   out_set->compute_derived_values();
 
+  // The unused short-term references are all collected into a single PocStFoll array
+  // of MAX_NUM_REF_PICS entries (see decoder_context::process_reference_picture_set).
+  // While each individual list is bounded above, the predicted-RPS construction can
+  // append the current-picture delta to an already-full source set, pushing the
+  // combined count past MAX_NUM_REF_PICS. Reject such sets to avoid an out-of-bounds
+  // write when filling PocStFoll.  Backport of upstream libde265 691f3a3c (1.0.20).
+  if (out_set->NumDeltaPocs > MAX_NUM_REF_PICS) {
+    out_set->NumNegativePics = 0;
+    out_set->NumPositivePics = 0;
+    out_set->NumDeltaPocs = 0;
+    out_set->NumPocTotalCurr_shortterm_only = 0;
+
+    errqueue->add_warning(DE265_WARNING_MAX_NUM_REF_PICS_EXCEEDED, false);
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

The bundled `libde265` 1.0.15 (`libde265/libde265/`, compiled via the cgo amalgamation `libde265-all.inl`) contains two out-of-bounds writes reachable when decoding an untrusted HEVC/HEIC bitstream. Both are fixed upstream in the 1.0.x line; this PR backports the two minimal upstream fixes onto the bundled copy. Refs #43.

## Vulnerabilities

### CVE-2026-33165 — heap OOB write (`set_SliceHeaderIndex`)
`GHSA-653q-9f73-8hvg`, CWE-787. A crafted stream changes the SPS so that `PicWidthInCtbsY` / `PicHeightInCtbsY` stay constant but `Log2CtbSizeY` changes. `de265_image::alloc_image()` only reallocated the CTB metadata array when the *unit dimensions* changed, leaving a stale `ctb_info.log2unitSize`. `read_coding_tree_unit()` (`slice.cc:2866`) then calls `set_SliceHeaderIndex()` (`image.h:740`), whose `x>>log2unitSize` indexing runs 2 bytes past the heap allocation — a heap-buffer-overflow WRITE.

Fix: also reallocate when `ctb_info.log2unitSize != sps->Log2CtbSizeY`. Backport of upstream `c7891e41` (released in 1.0.17).

### CVE-2026-49295 — OOB array write (`process_reference_picture_set`)
`GHSA-g2rg-wj66-w594`, CWE-787. The SPS parser validates `num_negative_pics` and `num_positive_pics` individually against `MAX_NUM_REF_PICS` (16), but predicted short-term RPS construction (`inter_ref_pic_set_prediction_flag=1`) can append the current-picture delta to an already-full source set, producing 17 aggregate entries. `process_reference_picture_set()` (`decctx.cc:1540`) then writes `PocStFoll[16]`, one past the 16-entry array.

Fix: reject any short-term RPS whose `NumDeltaPocs > MAX_NUM_REF_PICS` in `read_short_term_ref_pic_set()`. Backport of upstream `691f3a3c`.

## Verification

Built the **bundled** `libde265/libde265/` sources exactly as the cgo amalgamation does (`clang++ -std=c++11 -DHAVE_SSE4_1 -msse4.1 -I. -Ilibde265 -c libde265.cc`), with ASan+UBSan, ASLR off, linked against the public `de265_*` decode API. Three inputs per build, before vs after this PR:

| Input | Bundled 1.0.15 (before) | With this PR (after) |
|---|---|---|
| CVE-2026-33165 PoC (254 B) | `AddressSanitizer: heap-buffer-overflow` WRITE size 2 at `image.h:740` | clean, exit 0 |
| CVE-2026-49295 PoC | `runtime error: index 16 out of bounds for type 'int[16]'` at `decctx.cc:1540` | clean, exit 0 |
| valid HEVC stream (`girlshy.h265`) | decodes, exit 0 | decodes, exit 0 (no regression) |

## Notes

- Changes are confined to `libde265/libde265/image.cc` and `libde265/libde265/refpic.cc` — the files the amalgamation `#include`s and the cgo build actually compiles. No amalgamation regeneration needed.
- Diff: 2 files, +22/-1. No API/ABI change.